### PR TITLE
add id to event elements

### DIFF
--- a/src/js/packages/event-to-object/src/index.ts
+++ b/src/js/packages/event-to-object/src/index.ts
@@ -276,6 +276,7 @@ function convertElement(element: EventTarget | HTMLElement | null): any {
 const convertGenericElement = (element: HTMLElement) => ({
   tagName: element.tagName,
   boundingClientRect: { ...element.getBoundingClientRect() },
+  id: element.id,
 });
 
 const convertMediaElement = (element: HTMLMediaElement) => ({


### PR DESCRIPTION
Add's element ID to the response returned to the server

It allows for logic like this:

```python
def get_input_by_id(e: dict, input_id: str) -> dict:
    for input in e["target"]["elements"]:
        if input.get("id") == input_id:
            return input
    raise Exception(f"Input not found: {input_id}")
```

Currently, inputs can only be grabbed by their index which is brittle.