### PR TITLE
Add line to caller_info

### DIFF
--- a/src/py/reactpy/reactpy/core/hooks.py
+++ b/src/py/reactpy/reactpy/core/hooks.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 from functools import lru_cache
 import hashlib
+import linecache
 import sys
 from collections.abc import Coroutine, Sequence
 from hashlib import md5
@@ -103,7 +104,10 @@ def get_caller_info():
         if patch_path is not None:
             break
     # Extract the relevant information: file path and line number and hash it
-    return f"{caller_frame.f_code.co_filename} {caller_frame.f_lineno} {patch_path}"
+    filename = caller_frame.f_code.co_filename
+    lineno = caller_frame.f_lineno
+    line  = linecache.getline(filename, lineno)
+    return f"{filename} {lineno} {line}, {patch_path}"
 
 
 __DEBUG_CALLER_INFO_TO_STATE_KEY = {}

--- a/src/py/reactpy/reactpy/core/hooks.py
+++ b/src/py/reactpy/reactpy/core/hooks.py
@@ -103,10 +103,10 @@ def get_caller_info():
         patch_path = render_frame.f_locals.get("patch_path_for_state")
         if patch_path is not None:
             break
-    # Extract the relevant information: file path and line number and hash it
+    # Extract the relevant information: file path, line number, and line and hash it
     filename = caller_frame.f_code.co_filename
     lineno = caller_frame.f_lineno
-    line  = linecache.getline(filename, lineno)
+    line = linecache.getline(filename, lineno)
     return f"{filename} {lineno} {line}, {patch_path}"
 
 


### PR DESCRIPTION
This adds more protections against accidentally mixing up state recovery values. This is def a corner case.